### PR TITLE
Updated FAOSearch function only

### DIFF
--- a/FAOSTAT/R/FAOsearch.R
+++ b/FAOSTAT/R/FAOsearch.R
@@ -24,7 +24,7 @@ FAOsearch = function(code = NULL, dataset = NULL, topic = NULL, latest = FALSE, 
     if(!is.null(topic)){
         wfp_identifier <- wfp_identifier[grep(topic, wfp_identifier[,"Topic"]),]}
     if(latest == T){
-        wfp_identifier <- results[order(results$DateUpdate, decreasing = T),]}
+        wfp_identifier <- wfp_identifier[order(wfp_identifier$DateUpdate, decreasing = T),]}
     if(full == F){
         return(wfp_identifier[,c("DatasetCode",
                           "DatasetName",

--- a/FAOSTAT/R/FAOsearch.R
+++ b/FAOSTAT/R/FAOsearch.R
@@ -1,107 +1,35 @@
-##' A function to find the domain, element and item code for a
-##' specific FAOSTAT query.
-##'
+##' Search FAOSTAT tables 
+##' 
+##' Get full list of datasets from the FAOSTAT database with the Code, Dataset Name and Topic.
+##' 
+##' @param code Specific 2-3 character code for dataset, listed as DatasetCode
+##' @param dataset Name of dataset, listed as DatasetName
+##' @param topic Dataset topic from list
+##' @param latest Sort list by latest updates
+##' @param full defaults False, return the full table with all columns
+##' 
 ##' @export
 
-FAOsearch = function(){
-    with(FAOmetaTable, {
-        ## Find the Group code
-        gc = NA
-        ## while loop iterates until a valid value is supplied
-        while(length(gc)==0 || is.na(gc)){
-            cat(paste(paste("(", 1:length(groupTable$groupName), ") ",
-                            groupTable$groupName, sep = ""), collapse = "\n"))
-            gcn = readline("\nWhich Group are you looking for: ")
-            gc = groupTable[as.numeric(gcn), "groupCode"]
-        }
+FAOsearch = function(code = NULL, dataset = NULL, topic = NULL, latest = FALSE, full = FALSE){
 
-        ## Find the Domain code
-        subdomainTable = subset(domainTable, groupCode == gc)
-        dc = NA
-        ## while loop iterates until a valid value is supplied
-        while(length(dc)==0 || is.na(dc)){
-            cat(paste(paste("(", 1:length(subdomainTable$domainName), ") ",
-                            subdomainTable$domainName, sep = ""),
-                      collapse = "\n"))
-            dcn = readline("\nWhich Domain are you looking for: ")
-            dc = subdomainTable[as.numeric(dcn), "domainCode"]
-        }
-
-        ## Individual or aggregated item
-        useAgg = NA
-        while(is.na(useAgg) || !useAgg %in% c("0", "1")){
-            cat("(0) Individual item (e.g. Apples, Wheat)\n")
-            cat("(1) Aggregated item (e.g. Total cereals, Total meat\n")
-            useAgg = readline(paste("Are you looking for individual item or",
-                              "aggregated item:"))
-        }
-
-        if(as.numeric(useAgg)){
-            ## Find the Item Aggregated code
-            subitemTable = subset(itemAggTable, domainCode == dc)
-            ic = NA
-            ## while loop iterates until a valid value is supplied
-            while(length(ic)==0 || is.na(ic)){
-                cat(paste(paste("(", 1:length(subitemTable$itemName), ") ",
-                                subitemTable$itemName, sep = ""),
-                          collapse = "\n"))
-                icn = readline(paste("\nWhich Item are you looking for?",
-                                     "('All' for everything):"))
-                if(icn == "All")
-                    icn = 1:length(subitemTable$itemName)
-                ic = subitemTable[as.numeric(icn), "itemCode"]
-            }
-        } else {
-
-            ## Find the Item code
-            subitemTable = subset(itemTable, domainCode == dc)
-            ic = NA
-            ## while loop iterates until a valid value is supplied
-            while(length(ic)==0 || is.na(ic)){
-                cat(paste(paste("(", 1:length(subitemTable$itemName), ") ",
-                                subitemTable$itemName, sep = ""),
-                          collapse = "\n"))
-                icn = readline(paste("\nWhich Item are you looking for?",
-                                     "('All' for everything): "))
-                if(icn == "All")
-                    icn = 1:length(subitemTable$itemName)
-                ic = subitemTable[as.numeric(icn), "itemCode"]
-            }
-        }
-
-        ## Find the Element code
-        subelementTable = subset(elementTable, domainCode == dc)
-        ec = NA
-        ## while loop iterates until a valid value is supplied
-        while(length(ec)==0 || is.na(ec)){
-            cat(paste(paste("(", 1:length(subelementTable$elementName), ") ",
-                            subelementTable$elementName, sep = ""),
-                      collapse = "\n"))
-            ecn = readline(paste("\nWhich Element are you looking for?",
-                                 "('All' for everything):"))
-            if(ecn == "All")
-                ecn = 1:length(subelementTable$elementName)
-            ec = subelementTable[as.numeric(ecn), "elementCode"]
-        }
-
-        tmp = expand.grid(dc, ic, ec, stringsAsFactors = FALSE)
-        colnames(tmp) = c("domainCode", "itemCode", "elementCode")
-        tmp = merge(tmp, domainTable[, c("domainCode", "domainName")],
-            all.x = TRUE)
-        tmp = merge(tmp, subitemTable[, c("itemCode", "itemName")],
-            all.x = TRUE)
-        final.df = merge(tmp, subelementTable[, c("elementCode", "elementName")],
-            all.x = TRUE)
-        final.df$name =
-            with(final.df, paste(domainName, itemName, elementName, sep = "_"))
-        final.df$domainName = NULL
-        final.df$itemName = NULL
-        final.df$elementName = NULL
-        .LastSearch <<- final.df
-        cat("\n** Search result saved as .LastSearch**\n")
-
-    }
-    )
+# Try downloading latest version from Fenix Services (host of FAOSTAT data), if fails due to connection error, use local .rdata version included with package within /data folder
+    download_from_fenix <- try(wfp_identifier <- XML::xmlToDataFrame(XML::xmlParse(
+                                            "http://fenixservices.fao.org/faostat/static/bulkdownloads/datasets_E.xml"), 
+                                            stringsAsFactors = F), silent = TRUE) 
+    
+    if(!is.null(code)){
+        wfp_identifier <- wfp_identifier[code == wfp_identifier[,"DatasetCode"],]}
+    if(!is.null(dataset)){
+        wfp_identifier <- wfp_identifier[grep(dataset, wfp_identifier[,"DatasetName"]),]}
+    if(!is.null(topic)){
+        wfp_identifier <- wfp_identifier[grep(topic, wfp_identifier[,"Topic"]),]}
+    if(latest == T){
+        wfp_identifier <- results[order(results$DateUpdate, decreasing = T),]}
+    if(full == F){
+        return(wfp_identifier[,c("DatasetCode",
+                          "DatasetName",
+                          "DateUpdate")])}
+    if(full == T){
+        return(wfp_identifier)}
+    else(return("Invalid query"))
 }
-
-utils::globalVariables(names = c("FAOmetaTable"))


### PR DESCRIPTION
Apologies for dropping the ball before with the former pull request. Here is only the single change for the `FAOSearch` function. 

It works by retrieving the latest dataset catalogue from FAOSTAT, including FileLink to download zipped table

**Demo**:

Get full FAOSTAT catalogue, including topic attributes, full description and download link, sorted by latest updated dataset.
`fao <- FAOsearch(full=T, , latest = TRUE) ` 

Get datasets with keyword in name:
`FAOsearch(dataset = "Crop")`
 
Get download link for dataset by it's code:
```
QI <- FAOsearch(code = "QI", full = TRUE)
download.file(QI$FileLocation, "QI.zip")
```

Can also automate to get the full table via convenience function:
```
fao <- FAOsearch(full=T)
# Retrieved: https://github.com/muuankarski/faobulk/blob/master/R/get_data.R
get_data <- function(DatasetCode = "QP"){
  datas <- fao
  urli <- datas[datas$DatasetCode == DatasetCode,]$FileLocation
  fly <- tempfile(fileext = ".zip")
  download.file(url = urli, destfile = fly)
  dat <- readr::read_csv(fly)
  names(dat) <- tolower(sub(" ", "_", names(dat)))
  return(dat)
} 
``` 
`population <- get_data("OA")`